### PR TITLE
v0.5.0 使用 `finish_reason = repeat` 来标识因检测到重复内容输出而阻断响应

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func init() {
 var (
 	MoonPalace = &cobra.Command{
 		Use:           "moonpalace",
-		Version:       "v0.4.3",
+		Version:       "v0.5.0",
 		Short:         "MoonPalace is a command-line tool for debugging the Moonshot AI HTTP API",
 		SilenceErrors: true,
 		SilenceUsage:  true,


### PR DESCRIPTION
在 `n>1` 的场合，只要有任意一个 `choice` 被检测到重复内容输出，则其余所有尚未生成 `finish_reason` 的 `choices` 都将被强制设置 `finish_reason=repeat`。